### PR TITLE
Option to not timeout while praying

### DIFF
--- a/src/main/java/com.onetickflick/OneTickFlickConfig.java
+++ b/src/main/java/com.onetickflick/OneTickFlickConfig.java
@@ -75,6 +75,13 @@ public interface OneTickFlickConfig extends Config
 		return 30;
 	}
 
+	@ConfigItem(
+			keyName = "overlayTimeoutOnPrayer",
+			name = "Timeout while praying",
+			position = 5,
+			description = "Whether or not the overlay should timeout while you are praying")
+	default boolean overlayTimeoutOnPrayer() { return true; }
+
 	@Units(Units.MILLISECONDS)
 	@ConfigItem(
 			keyName = "clickDelayMilliseconds",

--- a/src/main/java/com.onetickflick/OneTickFlickConfig.java
+++ b/src/main/java/com.onetickflick/OneTickFlickConfig.java
@@ -75,13 +75,6 @@ public interface OneTickFlickConfig extends Config
 		return 30;
 	}
 
-	@ConfigItem(
-			keyName = "overlayTimeoutOnPrayer",
-			name = "Timeout while praying",
-			position = 5,
-			description = "Whether or not the overlay should timeout while you are praying")
-	default boolean overlayTimeoutOnPrayer() { return true; }
-
 	@Units(Units.MILLISECONDS)
 	@ConfigItem(
 			keyName = "clickDelayMilliseconds",


### PR DESCRIPTION
Hey I like this plugin, it's pretty handy :)

I thought it would be nice to have an option not to timeout while praying, for example you don't want the overlay while not praying but do while praying (maybe you'll pray for a while and then flick later)

By default its set to true, which matches current behaviour

I've never wrote java before so apologies!

Example:

https://github.com/user-attachments/assets/1f1e6b58-0413-40dc-8a2c-1f4a30fe4ae0


