### PR TITLE
Add movement styles and a reverse direction option

### DIFF
--- a/src/main/java/com.onetickflick/OneTickFlickConfig.java
+++ b/src/main/java/com.onetickflick/OneTickFlickConfig.java
@@ -7,6 +7,8 @@ import java.awt.*;
 @ConfigGroup("onetickflick")
 public interface OneTickFlickConfig extends Config
 {
+	enum MovementStyle { SINE, LINEAR, EASE_IN_OUT, EASE_OUT_IN, PING_PONG }
+
 	@ConfigItem(
 			keyName = "detectPrayerBookClicks",
 			name = "Detect prayer book clicks",
@@ -78,8 +80,24 @@ public interface OneTickFlickConfig extends Config
 		return 0;
 	}
 
+	@ConfigItem(
+			keyName = "movementStyle",
+			name = "Movement Style",
+			description = "The animation style of the tick bar.",
+			position = 6
+	)
+	default MovementStyle movementStyle() { return MovementStyle.SINE; }
+
+	@ConfigItem(
+			keyName = "reverseDirection",
+			name = "Reverse Direction",
+			description = "Reverses the direction of the tick bar.",
+			position = 7
+	)
+	default boolean reverseDirection() { return false; }
+
 	@ConfigSection(
-			position = 6,
+			position = 8,
 			name = "Overlay Timeout",
 			description = "Configure the overlay timeout settings"
 	)
@@ -110,7 +128,7 @@ public interface OneTickFlickConfig extends Config
 	}
 
 	@ConfigSection(
-			position = 7,
+			position = 9,
 			name = "Colors",
 			description = "Recolor the various elements of the overlay"
 	)

--- a/src/main/java/com.onetickflick/OneTickFlickPlugin.java
+++ b/src/main/java/com.onetickflick/OneTickFlickPlugin.java
@@ -47,6 +47,7 @@ public class OneTickFlickPlugin extends Plugin
 
 	@Getter(AccessLevel.PACKAGE)
 	private int combo;
+	private int tickCount = 0;
 
 	@Override
 	protected void startUp()
@@ -54,6 +55,7 @@ public class OneTickFlickPlugin extends Plugin
 		lastTickTime = System.currentTimeMillis();
 		lastInteraction = lastTickTime;
 		combo = 0;
+		tickCount = 0;
 
 		overlay.setVisible(true);
 		overlayManager.add(overlay);
@@ -107,6 +109,12 @@ public class OneTickFlickPlugin extends Plugin
 			case "swipeLineWidth":
 				overlay.setSwipeLineWidth(config.swipeLineWidth());
 				break;
+			case "movementStyle":
+				overlay.setMovementStyle(config.movementStyle());
+				break;
+			case "reverseDirection":
+				overlay.setReverseDirection(config.reverseDirection());
+				break;
 		}
 	}
 
@@ -125,6 +133,7 @@ public class OneTickFlickPlugin extends Plugin
 		currentTickClicks.clear();
 		overlay.newTick();
 		lastTickTime = System.currentTimeMillis();
+		tickCount++;
 
 		if (!nextTickClicks.isEmpty())
 		{
@@ -197,6 +206,14 @@ public class OneTickFlickPlugin extends Plugin
 	long millisSinceTick()
 	{
 		return System.currentTimeMillis() - lastTickTime;
+	}
+
+	/**
+	 * Returns the current tick count for ping-pong animation.
+	 */
+	int getTickCount()
+	{
+		return tickCount;
 	}
 
 	/**


### PR DESCRIPTION
Implemented some different movement styles for the tick bar, as well as a reverse direction option.

The default option (Sine) uses the cos() function like the small progress bar on the QuickPray orb. I personally prefer the current Linear option, but thought the majority of people would be more comfortable with Sine as the default.

The ping-pong effect is pretty useful as well, makes it easier to focus on the flicking (for me personally).

I'm not sure how useful reversing the direction of the tick progress is, but someone would probably appreciate it.