### PR TITLE
Allow more compact overlay height

### DIFF
--- a/src/main/java/com.onetickflick/OneTickFlickOverlay.java
+++ b/src/main/java/com.onetickflick/OneTickFlickOverlay.java
@@ -11,12 +11,16 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 
 public class OneTickFlickOverlay extends Overlay
 {
-	private static final int MIN_BAR_HEIGHT = 12;
-	private static final int TEXT_SPACE = 20;
+	private static final int MIN_BAR_HEIGHT = 5;
+	private static final int HIDDEN_COMBO_SPACE = 6;
+	private static final int COMBO_TEXT_SPACE = 20;
+	private static final int DEFAULT_BAR_HEIGHT = 12;
+	private static final int DEFAULT_TEXT_SPACE = 20;
 	private static final int X_SIZE = 4;
 	private static final int TICK_LENGTH = 600;
-	private static final Dimension MIN_SIZE = new Dimension(50, MIN_BAR_HEIGHT + TEXT_SPACE);
-	private static final Dimension DEFAULT_SIZE = new Dimension(150, MIN_BAR_HEIGHT + TEXT_SPACE);
+	private static final int MIN_WIDTH = 50;
+	private static final int DEFAULT_WIDTH = 150;
+	private static final Dimension DEFAULT_SIZE = new Dimension(DEFAULT_WIDTH, DEFAULT_BAR_HEIGHT + DEFAULT_TEXT_SPACE);
 
 	private final OneTickFlickPlugin plugin;
 	private final List<Integer> clickOffsets = new CopyOnWriteArrayList<>();
@@ -26,7 +30,6 @@ public class OneTickFlickOverlay extends Overlay
 	private int greenStart;
 	@Setter
 	private int greenEnd;
-	@Setter
 	private boolean showCombo;
 	@Setter
 	private Color targetZoneColor;
@@ -61,6 +64,7 @@ public class OneTickFlickOverlay extends Overlay
 
 		setPosition(OverlayPosition.BOTTOM_LEFT);
 		setPreferredSize(DEFAULT_SIZE);
+		setMinimumSize(getMinimumHeight());
 		setResizable(true);
 	}
 
@@ -84,6 +88,12 @@ public class OneTickFlickOverlay extends Overlay
 		return visible;
 	}
 
+	public void setShowCombo(boolean showCombo)
+	{
+		this.showCombo = showCombo;
+		setMinimumSize(getMinimumHeight());
+	}
+
 	@Override
 	public Dimension render(Graphics2D g)
 	{
@@ -95,44 +105,47 @@ public class OneTickFlickOverlay extends Overlay
 		Rectangle bounds = getBounds();
 		Dimension size = getPreferredSize() == null ? DEFAULT_SIZE : getPreferredSize();
 
+		int reservedSpace = getReservedSpace();
 		int width = size.width;
 		int height = size.height;
 		if (bounds != null && bounds.width > 0 && bounds.height > 0)
 		{
-			width = Math.max(bounds.width, MIN_SIZE.width);
-			height = Math.max(bounds.height, MIN_SIZE.height);
+			width = Math.max(bounds.width, MIN_WIDTH);
+			height = Math.max(bounds.height, getMinimumHeight());
 		}
 
-		int barHeight = Math.max(MIN_BAR_HEIGHT, height - TEXT_SPACE);
+		int barHeight = Math.max(MIN_BAR_HEIGHT, height - reservedSpace);
+		int barY = showCombo ? 0 : (height - barHeight) / 2;
 
 		int greenX1 = width * greenStart / TICK_LENGTH;
 		int greenX2 = width * greenEnd / TICK_LENGTH;
 
 		g.setColor(backgroundColor);
-		g.fillRect(0, 0, greenX1, barHeight);
-		g.fillRect(greenX2, 0, width - greenX2, barHeight);
+		g.fillRect(0, barY, greenX1, barHeight);
+		g.fillRect(greenX2, barY, width - greenX2, barHeight);
 
 		g.setColor(targetZoneColor);
-		g.fillRect(greenX1, 0, greenX2 - greenX1, barHeight);
+		g.fillRect(greenX1, barY, greenX2 - greenX1, barHeight);
 
 		long ms = plugin.millisSinceTick();
 		int swipeLineX = (int) (width * ms / (double) TICK_LENGTH);
-		swipeLineX = Math.min(swipeLineX, width - swipeLineWidth); // Ensure the swipe line does not go out of the bar
+		swipeLineX = Math.min(swipeLineX, width - swipeLineWidth);
 
 		g.setColor(swipeLineColor);
-		g.fillRect(swipeLineX, 0, swipeLineWidth, barHeight);
+		g.fillRect(swipeLineX, barY, swipeLineWidth, barHeight);
 
 		g.setColor(borderColor);
-		g.drawRect(0, 0, width, barHeight);
+		g.drawRect(0, barY, width, barHeight);
 
 		g.setColor(clickColor);
-		int y1 = barHeight / 2 - X_SIZE;
-		int y2 = barHeight / 2 + X_SIZE;
+		int xSize = Math.min(X_SIZE, Math.max(1, (barHeight - 1) / 2));
+		int y1 = barY + barHeight / 2 - xSize;
+		int y2 = barY + barHeight / 2 + xSize;
 		for (int offset : clickOffsets)
 		{
 			int x = width * offset / TICK_LENGTH;
-			g.drawLine(x - X_SIZE, y1, x + X_SIZE, y2);
-			g.drawLine(x - X_SIZE, y2, x + X_SIZE, y1);
+			g.drawLine(x - xSize, y1, x + xSize, y2);
+			g.drawLine(x - xSize, y2, x + xSize, y1);
 		}
 
 		if (showCombo)
@@ -140,10 +153,20 @@ public class OneTickFlickOverlay extends Overlay
 			g.setColor(comboTextColor);
 			String text = "Combo: " + plugin.getCombo();
 			int tx = (width - g.getFontMetrics().stringWidth(text)) / 2;
-			int ty = barHeight + g.getFontMetrics().getAscent() + 2;
+			int ty = barY + barHeight + g.getFontMetrics().getAscent() + 2;
 			g.drawString(text, tx, ty);
 		}
 
 		return new Dimension(width, height);
+	}
+
+	private int getMinimumHeight()
+	{
+		return MIN_BAR_HEIGHT + getReservedSpace();
+	}
+
+	private int getReservedSpace()
+	{
+		return showCombo ? COMBO_TEXT_SPACE : HIDDEN_COMBO_SPACE;
 	}
 }


### PR DESCRIPTION
## Summary

Allows the 1 Tick Flick overlay to be resized to a more compact height while keeping the existing Alt-drag resize behavior.

## Rationale

The overlay was already resizable, but the previous minimum height always reserved the full combo counter text space, even when the combo counter was hidden.

This follows the approach discussed in #13:
- use a smaller minimum bar height;
- keep a small amount of reserved space when the combo counter is hidden so the overlay can still be resized with Alt-drag;
- use the full combo text space only when the combo counter is enabled;
- vertically center the bar when the combo counter is hidden.

## Changes

- Reduced the minimum bar height.
- Added separate reserved space values for hidden and visible combo counter states.
- Updated the overlay minimum size when combo counter visibility changes.
- Centered the bar vertically when the combo counter is hidden.
- Kept the tick timing logic unchanged.

Closes #13

## Testing

- Tested overlay display with combo counter enabled and disabled.
- Tested Alt-drag resizing down to the compact minimum height.
- Verified the overlay can still be resized again after reaching the compact minimum.
- Verified target zone, swipe line, border, and click markers still render correctly.
- Ran 'gradle clean build -x test'.

Note: 'gradle clean build' with Gradle 9.5.1 fails on the existing test task because the repository has test sources but no discovered JUnit tests. This is unrelated to the overlay change.